### PR TITLE
BUGFIX: Fixed composer install name to match the js requirement in multiuser.yml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
   "require": {
     "silverstripe/cms": ">=3.1"
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "extra": {
+    "installer-name": "multiuser-editing"
+  }
 }


### PR DESCRIPTION
This pull adds an installer name that matches the JavaScript requirement in [multiuser.yml](https://github.com/silverstripe/silverstripe-multiuser-editing-alert/blob/master/_config/multiuser.yml#L10). As well as the image paths in the [multiUserEditing.js](https://github.com/silverstripe/silverstripe-multiuser-editing-alert/blob/master/javascript/multiUserEditing.js#L88).
