### PR TITLE
Stop entire tooltop from being hoverable when hidden.

### DIFF
--- a/css/multiuserediting.css
+++ b/css/multiuserediting.css
@@ -44,7 +44,7 @@ placement: on right side of ".breadcrumbs-wrapper" */
 	.multi-user-editing-alert-message {
 		position: absolute;
 		top: 100%;
-		left: 0;
+		left: -9999px;
 		width: 340px;
 		margin: 0;
 		opacity: 0;
@@ -56,6 +56,7 @@ placement: on right side of ".breadcrumbs-wrapper" */
 	/* Show message box on hover/focus of icon */
 	.multi-user-message-wrap:hover .multi-user-editing-alert-message,
 	.multi-user-message-wrap:focus .multi-user-editing-alert-message {
+		left: 0;		
 		opacity: 1;
 		-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	}


### PR DESCRIPTION
Display: none would stop the animation
Height: 0 would also require altering padding
z-index stacking prevents using that option

Pushing the item left out of the viewport seems to be the most robust solution in this case outside of moving to a JS solution. 

https://github.com/silverstripe/silverstripe-multiuser-editing-alert/issues/6
