### PR TITLE
Stop triggering USER_ERRORs when user is logged out

### DIFF
--- a/javascript/multiUserEditing.js
+++ b/javascript/multiUserEditing.js
@@ -38,8 +38,10 @@ jQuery.entwine("multiUserEditing", function($) {
 			if (typeof(pageID) !== 'undefined' && pageID !== false && pageID !== 0 && pageID !== '0') {
 
 				$.getJSON('admin/editing/set/' + pageID, function (data) {
-					self.updateUserLabels(data, pageID);
-					self.setUpdateTimeout(data);	//update every x seconds
+					if (data) {
+						self.updateUserLabels(data, pageID);
+						self.setUpdateTimeout(data);	//update every x seconds
+					}
 				});
 			}
 		},


### PR DESCRIPTION
Currently if the user is logged out while still having an admin window open the code triggers a user error. 

This code change returns false instead and doesn't update things. 

This solves issue #5